### PR TITLE
fix: emulated hue not working

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
   swag:
     image: ghcr.io/linuxserver/swag
     container_name: swag
-    privileged: true
-    network_mode: host
     cap_add:
       - NET_ADMIN
     environment:
@@ -41,15 +39,13 @@ services:
       - URL=${DUCKDNS_DOMAIN}.duckdns.org
       - SUBDOMAINS=
       - VALIDATION=duckdns
-      - CERTPROVIDER= #optional
-#      - DNSPLUGIN=cloudflare #optional
-      - PROPAGATION= #optional
+      - CERTPROVIDER=zerossl #optional
+      - DNSPLUGIN=cloudflare #optional
       - DUCKDNSTOKEN=${DUCKDNS_TOKEN}
       - EMAIL=terry.dervaux@gmail.com #optional
       - ONLY_SUBDOMAINS=false #optional
       - EXTRA_DOMAINS= #optional
       - STAGING=false #optional
-      - MAXMINDDB_LICENSE_KEY= #optional
     volumes:
       - ./config/swag:/config
     ports:

--- a/test/ha-emulated-hue-smoke-tests.sh
+++ b/test/ha-emulated-hue-smoke-tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# load dotenv variables
+source .env
+
+STATUS=$(curl -w '%{http_code}' \
+     -o /dev/null \
+     -s \
+     "http://$LAN_IP_ADDRESS:$EMULATED_HUE_LISTEN_PORT/description.xml")
+
+if [ $STATUS != 200 ]; then
+    echo "Test NOK"
+    exit 1;
+fi
+
+echo "Test OK"
+exit 0;
+    


### PR DESCRIPTION
Port 80 was required for emulated hue. The port was already taken by SWAG.